### PR TITLE
update bower version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 
 {
   "name": "include-media-export",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/eduardoboucas/include-media-export",
   "authors": [
     "Eduardo Boucas <mail@eduardoboucas.com>"


### PR DESCRIPTION
bower still installs version 1.0.0 with the old RegExp
