### PR TITLE
More robust implementation of readBreakpoints()

### DIFF
--- a/include-media.js
+++ b/include-media.js
@@ -28,11 +28,12 @@
 
       try {
         breakpoints = JSON.parse(removeQuotes(data));
-        return;
-      } catch (err) {}
-    } 
-    
-    breakpoints = false;
+      } catch (err) {
+        breakpoints = false;
+      }
+    } else {
+      breakpoints = false;
+    }    
   }
 
   function isBreakpointActive(breakpoint) {

--- a/include-media.js
+++ b/include-media.js
@@ -33,7 +33,7 @@
       }
     } else {
       breakpoints = false;
-    }    
+    }
   }
 
   function isBreakpointActive(breakpoint) {

--- a/include-media.js
+++ b/include-media.js
@@ -28,10 +28,11 @@
 
       try {
         breakpoints = JSON.parse(removeQuotes(data));
+        return;
       } catch (err) {}
-    } else {
-      breakpoints = false;
-    }
+    } 
+    
+    breakpoints = false;
   }
 
   function isBreakpointActive(breakpoint) {


### PR DESCRIPTION
At least in Firefox 53, the `body:after` content is updated with the JSON data once a matching media is found in CSS. However, when the viewport is resized and does no longer match *any* of the defined breakpoints, the `.content` reverts to `'none'`, a literal string value. This fails during JSON parsing, effectively leaving the `breakpoint` unchanged.

I also had the same issue with IE 11. I did not examine any closer there, but that also disappeared with this change.